### PR TITLE
Improve usability by using content closures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SlidingTabView",
+    platforms: [.iOS(.v13)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -9,32 +9,28 @@
 Please use Swift Package Manager to install **SlidingTabView**
 
 ## Usage
-Just instantiate and bind it to your state. That is it!
+Just instantiate, bind it to your state and add your tabs with their respective content. That is it!
 ```swift
-@State private var selectedTabIndex = 0
-SlidingTabView(selection: $selectedTabIndex,tabs: ["First Tab", "Second Tab"]
-```
+import SlidingTabView
 
-## Canvas Preview
-```swift
-struct SlidingTabConsumerView : View {
-    @State private var selectedTabIndex = 0
+struct MyView: View {
+
+    @State var selectedTab: Int = 0
 
     var body: some View {
-        VStack(alignment: .leading) {
-            SlidingTabView(selection: self.$selectedTabIndex, tabs: ["First", "Second"])
-            (selectedTabIndex == 0 ? Text("First View") : Text("Second View")).padding()
-            Spacer()
-        }
-            .padding(.top, 50)
-            .animation(.none)
-    }
-}
+        SlidingTabView(
+            selection: $selectedTab,
+            tabs: SlidingTab(title: "Hello") {
 
-@available(iOS 13.0.0, *)
-struct SlidingTabView_Previews : PreviewProvider {
-    static var previews: some View {
-        SlidingTabConsumerView()
+                Text("Hello")
+
+            },
+            SlidingTab(title: "World!") {
+
+                Text("World!")
+
+            }
+        )
     }
 }
 ```

--- a/Sources/SlidingTabView/SlidingTab.swift
+++ b/Sources/SlidingTabView/SlidingTab.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  
+//
+//  Created by Tim Fraedrich on 17.01.21.
+//
+
+import Foundation
+import SwiftUI
+
+public struct SlidingTab {
+    
+    public let title: String
+    public let content: () -> AnyView
+    
+    public init<Content: View>(title: String, @ViewBuilder content: @escaping () -> Content) {
+        
+        self.title = title
+        self.content = {
+            AnyView(content())
+        }
+        
+    }
+    
+}

--- a/Sources/SlidingTabView/SlidingTab.swift
+++ b/Sources/SlidingTabView/SlidingTab.swift
@@ -1,8 +1,25 @@
 //
-//  File.swift
+//  SlidingTab.swift
 //  
+//  Copyright (c) 2019 Quynh Nguyen
 //
-//  Created by Tim Fraedrich on 17.01.21.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 import Foundation


### PR DESCRIPTION
This pull request aims to use a more SwiftUI-like approach to content being displayed. With the help of content closures there is no need to update the content manually inside the hosting view.

To express the changes in code, this is how the usability is improved:

**Before:**
```swift        
VStack(alignment: .leading) {
    SlidingTabView(
        selection: self.$selectedTabIndex,
        tabs: ["First", "Second"]
    ),
    (selectedTabIndex == 0 ? Text("First View") : Text("Second View")).padding()
    Spacer()
}
```

**After:**
```swift
SlidingTabView(
    selection: $selectedTab,
    tabs: SlidingTab(title: "Hello") {
        Text("Hello")
    },
    SlidingTab(title: "World!") {
        Text("World!")
    }
)
```

Note: Because I had problems debugging the code I also edited the Package.swift, to resolve the errors. This ensures a required platform of iOS 13 or above. The README was also updated.