### PR TITLE
New functionality: Swipe between pages

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SlidingTabView",
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -12,15 +13,14 @@ let package = Package(
             targets: ["SlidingTabView"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/GeorgeElsham/ViewExtractor", from: "2.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SlidingTabView",
-            dependencies: [],
+            dependencies: ["ViewExtractor"],
             path: "Sources"),
         .testTarget(
             name: "SlidingTabViewTests",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Please use Swift Package Manager to install **SlidingTabView**
 Just instantiate and bind it to your state. That is it!
 ```swift
 @State private var selectedTabIndex = 0
-SlidingTabView(selection: $selectedTabIndex,tabs: ["First Tab", "Second Tab"]
+SlidingTabView(selection: $selectedTabIndex,tabs: ["First Tab", "Second Tab"]) {
+    Text("First Page")
+    Text("Second Page")
+}
 ```
 
 ## Canvas Preview
@@ -21,17 +24,18 @@ struct SlidingTabConsumerView : View {
     @State private var selectedTabIndex = 0
 
     var body: some View {
-        VStack(alignment: .leading) {
-            SlidingTabView(selection: self.$selectedTabIndex, tabs: ["First", "Second"])
-            (selectedTabIndex == 0 ? Text("First View") : Text("Second View")).padding()
-            Spacer()
+        SlidingTabView(selection: self.$selectedTabIndex,
+                       tabs: ["First", "Second"],
+                       font: .body,
+                       activeAccentColor: Color.blue,
+                       selectionBarColor: Color.blue) {
+            Text("First View")
+            Text("Second View")
         }
-            .padding(.top, 50)
-            .animation(.none)
     }
 }
 
-@available(iOS 13.0.0, *)
+@available(iOS 14.0.0, *)
 struct SlidingTabView_Previews : PreviewProvider {
     static var previews: some View {
         SlidingTabConsumerView()

--- a/Sources/SlidingTabView/SlidingTabView.swift
+++ b/Sources/SlidingTabView/SlidingTabView.swift
@@ -27,15 +27,6 @@ import SwiftUI
 @available(iOS 13.0, *)
 public struct SlidingTabView : View {
     
-    // MARK: Internal State
-    
-    /// Internal state to keep track of the selection index
-    @State private var selectionState: Int = 0 {
-        didSet {
-            selection = selectionState
-        }
-    }
-    
     // MARK: Required Properties
     
     /// Binding the selection index which will  re-render the consuming view
@@ -113,8 +104,7 @@ public struct SlidingTabView : View {
             HStack(spacing: 0) {
                 ForEach(self.tabs, id:\.self) { tab in
                     Button(action: {
-                        let selection = self.tabs.firstIndex(of: tab) ?? 0
-                        self.selectionState = selection
+                        self.selection = self.tabs.firstIndex(of: tab)!
                     }) {
                         HStack {
                             Spacer()
@@ -152,11 +142,11 @@ public struct SlidingTabView : View {
     // MARK: Private Helper
     
     private func isSelected(tabIdentifier: String) -> Bool {
-        return tabs[selectionState] == tabIdentifier
+        return tabs[selection] == tabIdentifier
     }
     
     private func selectionBarXOffset(from totalWidth: CGFloat) -> CGFloat {
-        return self.tabWidth(from: totalWidth) * CGFloat(selectionState)
+        return self.tabWidth(from: totalWidth) * CGFloat(selection)
     }
     
     private func tabWidth(from totalWidth: CGFloat) -> CGFloat {


### PR DESCRIPTION
Added this new functionality requested in #5 which I think is quite useful.  The functionality backed by native TabView component with `.tabViewStyle(.page)` which is only available after iOS 14, thus I updated the availability.

Also the pages do not have to be separate components now, they can be passed as we do in TabView, e.g:
```
SlidingTabView(selection: self.$selectedTabIndex, tabs: ["First", "Second"]) {
    Text("First View")
    Text("Second View")
}
```
Note that this change is not backward compatible so I believe increasing the version to 2.0 is necessary.

In the first commit removed `@State` and used the `@Binding` property instead this also Fixes #7 and Fixes #10.

Fixes #5 

https://user-images.githubusercontent.com/9766788/215855151-8d50381c-57da-402a-832c-81f63da578c1.mov

